### PR TITLE
Support golang version 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/c9s/callbackgen
+
+go 1.18
+
+require golang.org/x/tools v0.1.11
+
+require (
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
+golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=


### PR DESCRIPTION
When I used callbackgen in golang 1.18, I encountered this error message.
```
callbackgen: internal error: package "context" without types was imported from "github.com/yhsiang/wenshan/pkg/exchange/tokenlon"
exchange.go:17: running "callbackgen": exit status 1
```
Seems it used the wrong version of `golang.org/x/tools` if `golang.org/x/tools@v0.0.0` exist in my system.

I created the go.mod to use `golang.org/x/tools@v0.1.11` directly to void wrong importing for `golang.org/x/tools`